### PR TITLE
feat: add email verification flow

### DIFF
--- a/Insiderback-backup260825/src/routes/auth.routes.js
+++ b/Insiderback-backup260825/src/routes/auth.routes.js
@@ -13,6 +13,7 @@ import {
   /* Users  */
   registerUser,
   loginUser,
+  verifyEmail,
 
   /* Magic-link  */
   setPasswordWithToken,
@@ -99,6 +100,11 @@ router.post(
    VALIDAR TOKEN (solo lectura) — usado antes de mostrar el form
    ════════════════════════════════════════════════════════════════ */
 router.get("/validate-token/:token", validateToken);
+
+/* ════════════════════════════════════════════════════════════════
+   VERIFY EMAIL
+   ════════════════════════════════════════════════════════════════ */
+router.get("/verify-email/:token", verifyEmail);
 
 /* ════════════════════════════════════════════════════════════════
    STAFF: crear/vincular y listar


### PR DESCRIPTION
## Summary
- send verification email on user registration
- add verify email endpoint and block login until confirmed

## Testing
- `npm test` *(fails: Missing script "test" )*

------
https://chatgpt.com/codex/tasks/task_e_68ae02e54db08329bc1985e2e170d88d