### PR TITLE
feat: add agency markup and document roles

### DIFF
--- a/Insiderback-backup260825/src/controllers/travelgate.controller.js
+++ b/Insiderback-backup260825/src/controllers/travelgate.controller.js
@@ -117,7 +117,8 @@ export const search = async (req, res, next) => {
       2: 0.10, // staff → +20%
       3: 0.10, // influencer → +10%
       4: 0.05, // corporate → +10%
-   
+      5: 0.05, // agency   → +5%
+
       99: 0.00 // admin → +0%
     }
 

--- a/Insiderback-backup260825/src/controllers/user.controller.js
+++ b/Insiderback-backup260825/src/controllers/user.controller.js
@@ -199,10 +199,10 @@ export const getInfluencerStats = async (req, res) => {
   try {
     // En producción, obtén estos datos desde req.user
     const userId = 5
-    const role = 2 // 2 = influencer
+    const role = 3 // 3 = influencer
 
     if (!userId) return res.status(401).json({ error: "Unauthorized" })
-    if (role !== 2) return res.status(403).json({ error: "Only influencers can access this endpoint" })
+    if (role !== 3) return res.status(403).json({ error: "Only influencers can access this endpoint" })
 
     // 1) Traer códigos del influencer
     const codes = await models.DiscountCode.findAll({
@@ -299,9 +299,9 @@ export const getInfluencerStats = async (req, res) => {
 }
 
 const ROLE_MAP = {
-  INFLUENCER: { code: 2, label: "Influencer" },
-  CORPORATE : { code: 3, label: "Corporate"  },
-  AGENCY    : { code: 4, label: "Agency"     },
+  INFLUENCER: { code: 3, label: "Influencer" },
+  CORPORATE : { code: 4, label: "Corporate"  },
+  AGENCY    : { code: 5, label: "Agency"     },
 }
 
 const isEmail = (s = "") =>
@@ -313,7 +313,7 @@ export const requestPartnerInfo = async (req, res) => {
   try {
     const {
       requestedRoleKey,   // "INFLUENCER" | "CORPORATE" | "AGENCY"
-      requestedRole,      // 2 | 3 | 4  (opcional; se valida contra el key)
+      requestedRole,      // 3 | 4 | 5  (opcional; se valida contra el key)
       userId = null,
       name = "",
       email = "",

--- a/Insiderback-backup260825/src/middleware/auth.js
+++ b/Insiderback-backup260825/src/middleware/auth.js
@@ -15,7 +15,7 @@ export const authenticate = (req, res, next) => {
   }
 }
 
-/** Autoriza por rol numérico (ej. 100=admin, 2=influencer, 3=corporate, 4=agency, 1=staff, 0=regular) */
+/** Autoriza por rol numérico (ej. 99=admin, 5=agency, 4=corporate, 3=influencer, 2=staff, 1=guest, 0=regular) */
 export const authorizeRoles = (...allowed) => (req, res, next) => {
   const role = Number(req.user?.role)
   if (!allowed.includes(role)) return res.status(403).json({ error: "Forbidden" })

--- a/Insiderback-backup260825/src/routes/admin.routes.js
+++ b/Insiderback-backup260825/src/routes/admin.routes.js
@@ -4,9 +4,9 @@ import { createTenant, listTenants, updateTenant, deleteTenant } from "../contro
 
 const router = Router()
 
-router.get("/tenants", authenticate, authorizeRoles(100), listTenants)
-router.post("/tenants", authenticate, authorizeRoles(100), createTenant)
-router.put("/tenants/:id", authenticate, authorizeRoles(100), updateTenant)
-router.delete("/tenants/:id", authenticate, authorizeRoles(100), deleteTenant)
+router.get("/tenants", authenticate, authorizeRoles(99), listTenants)
+router.post("/tenants", authenticate, authorizeRoles(99), createTenant)
+router.put("/tenants/:id", authenticate, authorizeRoles(99), updateTenant)
+router.delete("/tenants/:id", authenticate, authorizeRoles(99), deleteTenant)
 
 export default router

--- a/Insiderback-backup260825/src/routes/user.routes.js
+++ b/Insiderback-backup260825/src/routes/user.routes.js
@@ -13,7 +13,7 @@ import { authenticate, authorizeRoles } from "../middleware/auth.js"
 const router = Router()
 
 /** ⚠️ TEMP: ruta pública (sin authenticate) */
-router.get("/me/influencer/stats",authenticate, authorizeRoles(2), getInfluencerStats)
+router.get("/me/influencer/stats",authenticate, authorizeRoles(3), getInfluencerStats)
 
 router.post("/request-info", requestPartnerInfo)
 


### PR DESCRIPTION
## Summary
- add agency role markup for TravelgateX searches
- document updated role codes across auth and partner requests
- align influencer stats route with new role id

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae02a90ebc8329b669d953e598ae2c