### PR TITLE
chore: remove node_modules from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+node_modules/
+dist/
+.env
+# Additional common ignores
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# Build output
+build/
+
+# Coverage
+coverage/
+
+# Others
+*.log
+


### PR DESCRIPTION
## Summary
- delete node_modules directories for backend and frontend backups
- add root .gitignore to exclude node_modules, dist, env files and logs

## Testing
- `npm test` *(backend, fails: Missing script "test")*
- `npm test` *(frontend, fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae11983db8832995b3265db3a9214c