### PR TITLE
Log JWT errors in auth middleware and add tests

### DIFF
--- a/Insiderback-backup260825/package.json
+++ b/Insiderback-backup260825/package.json
@@ -5,7 +5,8 @@
   "main": "src/app.js",
   "scripts": {
     "start": "node src/app.js",
-    "dev": "nodemon src/app.js"
+    "dev": "nodemon src/app.js",
+    "test": "node --test \"src/**/*.test.js\""
   },
   "dependencies": {
     "axios": "^1.11.0",

--- a/Insiderback-backup260825/src/middleware/auth.js
+++ b/Insiderback-backup260825/src/middleware/auth.js
@@ -10,8 +10,10 @@ export const authenticate = (req, res, next) => {
     const payload = jwt.verify(token, process.env.JWT_SECRET)
     req.user = payload   // ← { sub, kind, role, roles? }
     next()
-  } catch {
-    return res.status(401).json({ error: "Invalid token" })
+  } catch (err) {
+    console.error(err)
+    res.status(401).json({ error: "Invalid token" })
+    return next(err)
   }
 }
 

--- a/Insiderback-backup260825/src/middleware/auth.test.js
+++ b/Insiderback-backup260825/src/middleware/auth.test.js
@@ -1,0 +1,30 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { authenticate } from './auth.js';
+
+process.env.JWT_SECRET = 'test-secret';
+
+test('invalid JWT token results in 401 response', () => {
+  const req = { headers: { authorization: 'Bearer invalid.token.value' } };
+  const res = {
+    statusCode: 0,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+  let nextErr = null;
+  const next = (err) => {
+    nextErr = err;
+  };
+  authenticate(req, res, next);
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.body, { error: 'Invalid token' });
+  assert.ok(nextErr instanceof Error);
+});
+


### PR DESCRIPTION
## Summary
- log JWT verification failures in auth middleware and propagate to global error handler
- add unit test to ensure invalid JWT tokens return 401
- wire up test script using Node's test runner

## Testing
- `npm test --prefix Insiderback-backup260825`

------
https://chatgpt.com/codex/tasks/task_e_68ae11c78aa08329b1f842854e86b643