### PR TITLE
Make checkout price summary sticky only on large screens

### DIFF
--- a/insiderweb-backup260825/src/pages/Checkout/Checkout.jsx
+++ b/insiderweb-backup260825/src/pages/Checkout/Checkout.jsx
@@ -1320,7 +1320,7 @@ const Checkout = () => {
 
             {/* Right Column - Price Summary */}
             <div className="lg:col-span-1">
-              <div className="sticky top-8">
+              <div className="lg:sticky lg:top-8">
                 <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
                   {/* Hotel Info */}
                   <div className="flex items-start space-x-4 mb-6 pb-6 border-b border-gray-100">


### PR DESCRIPTION
## Summary
- Restrict checkout sidebar sticky behaviour to large screens using `lg:sticky` and `lg:top-8`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 68 errors, 10 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2f4cc1588329a70d02e5e6b16f36