### PR TITLE
Use rateKey for TGX quote calls

### DIFF
--- a/insiderweb-backup260825/src/features/booking/bookingSlice.js
+++ b/insiderweb-backup260825/src/features/booking/bookingSlice.js
@@ -7,21 +7,17 @@ const API_URL = import.meta.env.VITE_API_URL
 /* ────────────────────────── */
 
 // TravelgateX Quote
-// Ahora recibimos el optionRefId de la SEARCH (searchOptionRefId)
-// y el backend espera que se envíe bajo la clave optionRefId.
+// Accepts the room's rateKey and forwards it to the backend.
 export const quoteTravelgateRoom = createAsyncThunk(
   "booking/quoteTravelgateRoom",
-  async ({ searchOptionRefId }, { rejectWithValue }) => {
+  async ({ rateKey }, { rejectWithValue }) => {
     try {
-      console.log(
-        "🔍 Calling TravelgateX Quote API with searchOptionRefId:",
-        searchOptionRefId,
-      )
+      console.log("🔍 Calling TravelgateX Quote API with rateKey:", rateKey)
 
       const response = await fetch(`${API_URL}/tgx/quote`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ optionRefId: searchOptionRefId }),
+        body: JSON.stringify({ rateKey }),
       })
 
       if (!response.ok) {

--- a/insiderweb-backup260825/src/pages/Checkout/Checkout.jsx
+++ b/insiderweb-backup260825/src/pages/Checkout/Checkout.jsx
@@ -594,8 +594,8 @@ const Checkout = () => {
 
     setCurrentStep("quote")
     try {
-      console.log("🔍 Starting Quote with searchOptionRefId:", searchOptionRefId)
-      await dispatch(quoteTravelgateRoom({ searchOptionRefId }))
+      console.log("🔍 Starting Quote with rateKey:", searchOptionRefId)
+      await dispatch(quoteTravelgateRoom({ rateKey: searchOptionRefId }))
     } catch (error) {
       console.error("❌ Quote failed:", error)
     }


### PR DESCRIPTION
## Summary
- Forward `rateKey` to backend when quoting a room
- Dispatch quote action with `{ rateKey: searchOptionRefId }`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ✖ 77 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3a2b9e9483299120b06d29655bfb