### PR TITLE
Use rateKey when quoting Travelgate rooms

### DIFF
--- a/insiderweb-backup260825/src/pages/Checkout/Checkout.jsx
+++ b/insiderweb-backup260825/src/pages/Checkout/Checkout.jsx
@@ -80,7 +80,7 @@ const PaymentForm = ({
   onPaymentError,
   amount,
   currency,
-  searchOptionRefId,
+  rateKey,
   guestInfo,
   bookingData,
   isProcessing,
@@ -105,7 +105,7 @@ const PaymentForm = ({
         body: JSON.stringify({
           amount: Number(amount),
           currency,
-          searchOptionRefId,     // TGX lo usa; PARTNER lo ignora
+          rateKey, // TGX lo usa; PARTNER lo ignora
           guestInfo,
           bookingData,
           discount: discount || bookingData?.discount || null,
@@ -219,7 +219,7 @@ const PaymentForm = ({
 const GuaranteeForm = ({
   onSuccess,
   onError,
-  searchOptionRefId,
+  rateKey,
   guestInfo,
   bookingData,
   discount,
@@ -247,7 +247,7 @@ const GuaranteeForm = ({
 
   const submit = async (e) => {
     e.preventDefault()
-    if (!searchOptionRefId) return onError("Missing searchOptionRefId")
+    if (!rateKey) return onError("Missing rateKey")
 
     if (!form.number || !form.cvc || !form.month || !form.year) {
       return onError("Please complete card details.")
@@ -260,7 +260,7 @@ const GuaranteeForm = ({
     setIsProcessing(true)
     try {
       const payload = {
-        searchOptionRefId,
+        rateKey,
         guestInfo,
         bookingData: {
           ...bookingData,
@@ -486,7 +486,7 @@ const Checkout = () => {
       totalNights,
       quoteStatus,
       hasRateKey: selectedRoom?.rateKey,
-      searchOptionRefId,
+      rateKey: searchOptionRefId,
       quoteOptionRefId,
       paymentType: selectedRoom?.paymentType,
       discount,
@@ -594,17 +594,17 @@ const Checkout = () => {
 
     setCurrentStep("quote")
     try {
-      console.log("🔍 Starting Quote with searchOptionRefId:", searchOptionRefId)
-      await dispatch(quoteTravelgateRoom({ searchOptionRefId }))
+      console.log("🔍 Starting Quote with rateKey:", searchOptionRefId)
+      await dispatch(quoteTravelgateRoom({ rateKey: searchOptionRefId }))
     } catch (error) {
       console.error("❌ Quote failed:", error)
     }
   }
 
   const handleProceedToPayment = () => {
-    // En TGX, necesitamos el optionRefId de la SEARCH
+    // En TGX, necesitamos el rateKey de la SEARCH
     if (source === "TGX" && !searchOptionRefId) {
-      alert("Search optionRefId not available. Please try again.")
+      alert("Rate key not available. Please try again.")
       return
     }
     setCurrentStep("payment")
@@ -1211,7 +1211,7 @@ const Checkout = () => {
                         onPaymentError={handlePaymentError}
                         amount={getFinalTotalAmount()}
                         currency={getCurrency()}
-                        searchOptionRefId={searchOptionRefId} // TGX lo usa; PARTNER lo ignora
+                        rateKey={searchOptionRefId} // TGX usa rateKey; PARTNER lo ignora
                         guestInfo={guestForm}
                         bookingData={{
                           ...paymentBookingData,
@@ -1229,7 +1229,7 @@ const Checkout = () => {
                       <GuaranteeForm
                         onSuccess={handlePaymentSuccess}
                         onError={setPaymentError}
-                        searchOptionRefId={searchOptionRefId}
+                        rateKey={searchOptionRefId}
                         guestInfo={guestForm}
                         bookingData={paymentBookingData}
                         discount={paymentBookingData.discount}


### PR DESCRIPTION
## Summary
- quoteTravelgateRoom action now receives a `rateKey` to match updated API expectations
- Payment and guarantee flows validate and transmit `rateKey`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 67 errors, see log)*
- `npx eslint src/pages/Checkout/Checkout.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68ae3a2fc460832988be1d6a94844f4e