### PR TITLE
refactor: use rateKey identifiers for Travelgate quotes

### DIFF
--- a/insiderweb-backup260825/src/features/booking/bookingSlice.js
+++ b/insiderweb-backup260825/src/features/booking/bookingSlice.js
@@ -29,7 +29,7 @@ export const quoteTravelgateRoom = createAsyncThunk(
       console.log("✅ Quote response:", data)
       return {
         quote: data,
-        quoteOptionRefId: data?.optionRefId || null,
+        quoteRateKey: data?.rateKey || null,
       }
     } catch (err) {
       console.error("❌ Quote error:", err)
@@ -229,8 +229,8 @@ const initialState = {
   currency: "EUR",
 
   /* TravelgateX specific states */
-  searchOptionRefId: null,      // optionRefId devuelto por la SEARCH
-  quoteOptionRefId: null,       // optionRefId devuelto por la QUOTE
+  searchRateKey: null,          // rateKey devuelto por la SEARCH
+  quoteRateKey: null,           // rateKey devuelto por la QUOTE
   quoteStatus: "idle", // idle, loading, succeeded, failed
   quoteError: null,
   quoteData: null,
@@ -328,10 +328,10 @@ const bookingSlice = createSlice({
       // Room seleccionada (conservamos todo lo que venga)
       state.selectedRoom = room ? { ...room } : null
       state.roomId = room?.id ?? null
-      // optionRefId de la SEARCH (rateKey en nuestro mapeo)
-      state.searchOptionRefId = room?.optionRefId || room?.rateKey || null
+      // rateKey de la SEARCH
+      state.searchRateKey = room?.rateKey || room?.optionRefId || null
       // resetear info de quote previa
-      state.quoteOptionRefId = null
+      state.quoteRateKey = null
 
       // Normalizar hotel mostrado en checkout
       const normalizedHotel = hotel
@@ -484,7 +484,7 @@ const bookingSlice = createSlice({
       .addCase(quoteTravelgateRoom.fulfilled, (s, a) => {
         s.quoteStatus = "succeeded"
         s.quoteData = a.payload.quote
-        s.quoteOptionRefId = a.payload.quoteOptionRefId
+        s.quoteRateKey = a.payload.quoteRateKey
         console.log("✅ Quote data saved to Redux:", a.payload.quote)
       })
       .addCase(quoteTravelgateRoom.rejected, (s, a) => {

--- a/insiderweb-backup260825/src/pages/Checkout/Checkout.jsx
+++ b/insiderweb-backup260825/src/pages/Checkout/Checkout.jsx
@@ -452,8 +452,8 @@ const Checkout = () => {
     quoteStatus,
     quoteError,
     quoteData,
-    searchOptionRefId,
-    quoteOptionRefId,
+    searchRateKey,
+    quoteRateKey,
     currency,
   } = useSelector((s) => s.booking)
 
@@ -486,8 +486,8 @@ const Checkout = () => {
       totalNights,
       quoteStatus,
       hasRateKey: selectedRoom?.rateKey,
-      rateKey: searchOptionRefId,
-      quoteOptionRefId,
+      rateKey: searchRateKey,
+      quoteRateKey,
       paymentType: selectedRoom?.paymentType,
       discount,
     })
@@ -501,8 +501,8 @@ const Checkout = () => {
     totalNights,
     quoteStatus,
     quoteData,
-    searchOptionRefId,
-    quoteOptionRefId,
+    searchRateKey,
+    quoteRateKey,
     discount,
   ])
 
@@ -594,8 +594,8 @@ const Checkout = () => {
 
     setCurrentStep("quote")
     try {
-      console.log("🔍 Starting Quote with rateKey:", searchOptionRefId)
-      await dispatch(quoteTravelgateRoom({ rateKey: searchOptionRefId }))
+      console.log("🔍 Starting Quote with rateKey:", searchRateKey)
+      await dispatch(quoteTravelgateRoom({ rateKey: searchRateKey }))
     } catch (error) {
       console.error("❌ Quote failed:", error)
     }
@@ -603,7 +603,7 @@ const Checkout = () => {
 
   const handleProceedToPayment = () => {
     // En TGX, necesitamos el rateKey de la SEARCH
-    if (source === "TGX" && !searchOptionRefId) {
+    if (source === "TGX" && !searchRateKey) {
       alert("Rate key not available. Please try again.")
       return
     }
@@ -1211,7 +1211,7 @@ const Checkout = () => {
                         onPaymentError={handlePaymentError}
                         amount={getFinalTotalAmount()}
                         currency={getCurrency()}
-                        rateKey={searchOptionRefId} // TGX usa rateKey; PARTNER lo ignora
+                        rateKey={searchRateKey} // TGX usa rateKey; PARTNER lo ignora
                         guestInfo={guestForm}
                         bookingData={{
                           ...paymentBookingData,
@@ -1229,7 +1229,7 @@ const Checkout = () => {
                       <GuaranteeForm
                         onSuccess={handlePaymentSuccess}
                         onError={setPaymentError}
-                        rateKey={searchOptionRefId}
+                        rateKey={searchRateKey}
                         guestInfo={guestForm}
                         bookingData={paymentBookingData}
                         discount={paymentBookingData.discount}


### PR DESCRIPTION
## Summary
- rename quote/search optionRefId state fields to rateKey equivalents
- adjust Travelgate quote thunk to return quoteRateKey
- update Checkout flow to use new rateKey-based field names

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: unused vars)


------
https://chatgpt.com/codex/tasks/task_e_68ae6208e0e48329ab626e7f448ed95b