### PR TITLE
Accept rateKey as Travelgate option ID alias

### DIFF
--- a/Insiderback-backup260825/src/controllers/travelgate-payment.controller.js
+++ b/Insiderback-backup260825/src/controllers/travelgate-payment.controller.js
@@ -148,20 +148,22 @@ export const createTravelgatePaymentIntent = async (req, res) => {
     } = req.body
 
     // ✅ Normalizar: aceptamos varios alias
-    const idRaw =
-      req.body.searchOptionRefId ||
-      req.body.optionRefId ||
-      req.body.quoteOptionRefId ||
-      null
+      const idRaw =
+        req.body.searchOptionRefId ||
+        req.body.optionRefId ||
+        req.body.quoteOptionRefId ||
+        req.body.rateKey ||
+        null
 
-    if (!amount || !idRaw || !guestInfo) {
-      return badReq("MISSING_PARAMS", {
-        message: "amount, searchOptionRefId (or optionRefId), and guestInfo are required",
-        debug: {
-          hasAmount: Boolean(amount),
-          hasAnyOptionId: Boolean(idRaw),
-          hasGuestInfo: Boolean(guestInfo),
-        },
+      if (!amount || !idRaw || !guestInfo) {
+        return badReq("MISSING_PARAMS", {
+          message:
+            "amount, searchOptionRefId (or optionRefId, quoteOptionRefId, rateKey), and guestInfo are required",
+          debug: {
+            hasAmount: Boolean(amount),
+            hasAnyOptionId: Boolean(idRaw),
+            hasGuestInfo: Boolean(guestInfo),
+          },
       })
     }
 


### PR DESCRIPTION
## Summary
- Support `rateKey` when normalizing Travelgate option identifiers
- Clarify error message to mention `rateKey` and other aliases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae66a04d3c8329ab4b43c9bfae7134