### PR TITLE
Refactor login page to use AuthModal

### DIFF
--- a/insiderweb-backup260825/src/pages/Login/Login.jsx
+++ b/insiderweb-backup260825/src/pages/Login/Login.jsx
@@ -1,265 +1,36 @@
-/* ────────────────────────────────────────────────
-   src/pages/Login.jsx — 100 % COMPLETE, NO LINES OMITTED
-   ──────────────────────────────────────────────── */
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { useDispatch, useSelector } from "react-redux"
 import { useNavigate, useLocation } from "react-router-dom"
-import {
-  loginUser,
-  registerUser,
-  clearError,
-} from "../../features/auth/authSlice"
-import {
-  Mail,
-  Lock,
-  User,
-  Loader2,
-  Eye,
-  EyeOff,
-  ArrowLeft,
-} from "lucide-react"
+import AuthModal from "../../components/AuthModal/AuthModal"
+import { showAuthModal } from "../../features/auth/authSlice"
 
 const Login = () => {
-  const dispatch           = useDispatch()
-  const navigate           = useNavigate()
-  const location           = useLocation()
-  const { error, loading } = useSelector((s) => s.auth)
-
-  /* ─── form state ─────────────────────────────── */
-  const [isLogin,  setIsLogin]  = useState(true)
-  const [fullName, setFullName] = useState("")
-  const [email,    setEmail]    = useState("")
-  const [password, setPassword] = useState("")
-  const [confirm,  setConfirm]  = useState("")
-  const [showPass, setShowPass] = useState(false)
-  const [showConf, setShowConf] = useState(false)
+  const dispatch = useDispatch()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const { token, showAuthModal: modalVisible } = useSelector((s) => s.auth)
+  const [initialized, setInitialized] = useState(false)
 
   const from = location.state?.from || "/"
 
-  /* ─── submit ─────────────────────────────────── */
-  const handleSubmit = (e) => {
-    e.preventDefault()
-    dispatch(clearError())
-
-    if (!isLogin && password !== confirm) {
-      alert("Passwords do not match")
+  useEffect(() => {
+    if (token) {
+      navigate(from)
       return
     }
+    dispatch(showAuthModal({ mode: "login" }))
+    setInitialized(true)
+  }, [token, dispatch, navigate, from])
 
-    const action = isLogin
-      ? loginUser({ email, password })
-      : registerUser({ name: fullName, email, password })
+  useEffect(() => {
+    if (initialized && !modalVisible) {
+      navigate(from)
+    }
+  }, [initialized, modalVisible, navigate, from])
 
-    dispatch(action)
-      .unwrap()
-      .then(() => navigate(from))
-      .catch(() => {})
-  }
-
-  const toggleMode = () => {
-    setIsLogin(!isLogin)
-    dispatch(clearError())
-    setFullName("")
-    setPassword("")
-    setConfirm("")
-  }
-
-  /* ─── ui ─────────────────────────────────────── */
-  return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-50 p-6 sm:p-8">
-      <div className="relative w-full max-w-xl sm:max-w-2xl bg-white rounded-3xl shadow-2xl overflow-hidden">
-        {/* back btn if redirected */}
-        {location.state?.from && (
-          <button
-            onClick={() => navigate(-1)}
-            className="absolute left-4 top-4 text-gray-400 hover:text-gray-600 z-10"
-          >
-            <ArrowLeft className="h-5 w-5" />
-          </button>
-        )}
-
-        <div className="p-8 sm:p-12 lg:p-16">
-          {/* header */}
-          <div className="mb-10 text-center">
-            <h2 className="text-3xl font-bold text-gray-900 mb-2">
-              {isLogin ? "Welcome back" : "Create your account"}
-            </h2>
-            <p className="text-gray-600">
-              {isLogin
-                ? "Sign in to access your bookings and preferences"
-                : "Join thousands of travelers finding their perfect stay"}
-            </p>
-          </div>
-
-          {/* form */}
-          <form onSubmit={handleSubmit} className="space-y-5 max-w-lg mx-auto">
-            {error && (
-              <div className="bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-xl text-sm">
-                {error}
-              </div>
-            )}
-
-            {!isLogin && (
-              <div>
-                <label
-                  htmlFor="name"
-                  className="block text-sm font-medium text-gray-700 mb-2"
-                >
-                  Full name
-                </label>
-                <div className="relative">
-                  <User className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-gray-400" />
-                  <input
-                    id="name"
-                    type="text"
-                    value={fullName}
-                    onChange={(e) => setFullName(e.target.value)}
-                    required
-                    className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent"
-                    placeholder="Enter your full name"
-                  />
-                </div>
-              </div>
-            )}
-
-            <div>
-              <label
-                htmlFor="email"
-                className="block text-sm font-medium text-gray-700 mb-2"
-              >
-                Email address
-              </label>
-              <div className="relative">
-                <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-gray-400" />
-                <input
-                  id="email"
-                  type="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  required
-                  className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent"
-                  placeholder="Enter your email"
-                />
-              </div>
-            </div>
-
-            <div>
-              <label
-                htmlFor="password"
-                className="block text-sm font-medium text-gray-700 mb-2"
-              >
-                Password
-              </label>
-              <div className="relative">
-                <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-gray-400" />
-                <input
-                  id="password"
-                  type={showPass ? "text" : "password"}
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  required
-                  minLength={6}
-                  className="w-full pl-10 pr-12 py-3 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent"
-                  placeholder="Enter your password"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPass(!showPass)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
-                >
-                  {showPass ? (
-                    <EyeOff className="h-5 w-5" />
-                  ) : (
-                    <Eye className="h-5 w-5" />
-                  )}
-                </button>
-              </div>
-            </div>
-
-            {!isLogin && (
-              <div>
-                <label
-                  htmlFor="confirm"
-                  className="block text-sm font-medium text-gray-700 mb-2"
-                >
-                  Confirm password
-                </label>
-                <div className="relative">
-                  <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-gray-400" />
-                  <input
-                    id="confirm"
-                    type={showConf ? "text" : "password"}
-                    value={confirm}
-                    onChange={(e) => setConfirm(e.target.value)}
-                    required
-                    minLength={6}
-                    className="w-full pl-10 pr-12 py-3 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent"
-                    placeholder="Confirm your password"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowConf(!showConf)}
-                    className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
-                  >
-                    {showConf ? (
-                      <EyeOff className="h-5 w-5" />
-                    ) : (
-                      <Eye className="h-5 w-5" />
-                    )}
-                  </button>
-                </div>
-              </div>
-            )}
-
-            {isLogin && (
-              <div className="text-right">
-                <button
-                  type="button"
-                  onClick={() => alert("Forgot password flow coming soon!")}
-                  className="text-sm text-red-500 hover:text-red-600 font-medium"
-                >
-                  Forgot password?
-                </button>
-              </div>
-            )}
-
-            <button
-              type="submit"
-              disabled={loading}
-              className="w-full bg-red-500 text-white py-3 rounded-xl font-semibold hover:bg-red-600 transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
-            >
-              {loading ? (
-                <>
-                  <Loader2 className="h-5 w-5 animate-spin" />
-                  {isLogin ? "Signing in..." : "Creating account..."}
-                </>
-              ) : isLogin ? (
-                "Sign in"
-              ) : (
-                "Create account"
-              )}
-            </button>
-          </form>
-
-          {/* toggle mode */}
-          <div className="mt-8 text-center">
-            <p className="text-gray-600">
-              {isLogin ? "Don't have an account? " : "Already have an account? "}
-              <button
-                type="button"
-                onClick={toggleMode}
-                className="text-red-500 font-semibold hover:text-red-600 transition-colors"
-              >
-                {isLogin ? "Sign up" : "Sign in"}
-              </button>
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  )
+  return <AuthModal />
 }
 
 export default Login


### PR DESCRIPTION
## Summary
- Replace outdated login page with AuthModal-driven authentication to ensure consistent behavior and data handling.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: no-unused-vars in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6769c28083298a64fec9fb897f86