### PR TITLE
fix: apply correct markup for guest role

### DIFF
--- a/Insiderback-backup260825/src/controllers/travelgate.controller.test.js
+++ b/Insiderback-backup260825/src/controllers/travelgate.controller.test.js
@@ -2,16 +2,12 @@ import test from 'node:test'
 import assert from 'node:assert'
 import { getMarkup } from '../utils/markup.js'
 
-test('getMarkup for guest tiers', () => {
-  assert.strictEqual(getMarkup(1, 80), 0.5)
-  assert.strictEqual(getMarkup(1, 150), 0.4)
-  assert.strictEqual(getMarkup(1, 250), 0.3)
-})
-
-test('getMarkup for roles', () => {
-  assert.strictEqual(getMarkup(2, 100), 0.2)
+test('getMarkup returns expected markup for roles', () => {
+  assert.strictEqual(getMarkup(0, 100), 0.5)
+  assert.strictEqual(getMarkup(1, 100), 0.2)
+  assert.strictEqual(getMarkup(2, 100), 0.1)
   assert.strictEqual(getMarkup(3, 100), 0.1)
-  assert.strictEqual(getMarkup(4, 100), 0.1)
-  assert.strictEqual(getMarkup(5, 100), 0.05)
+  assert.strictEqual(getMarkup(4, 100), 0.05)
+  assert.strictEqual(getMarkup(100, 100), 0)
   assert.strictEqual(getMarkup(99, 100), 0)
 })

--- a/Insiderback-backup260825/src/utils/markup.js
+++ b/Insiderback-backup260825/src/utils/markup.js
@@ -1,14 +1,12 @@
-export function getMarkup(role, price) {
+export function getMarkup(role, _price) {
   const r = Number(role)
-  if (r === 1) {
-    const p = Number(price) || 0
-    if (p < 100) return 0.5
-    if (p < 200) return 0.4
-    return 0.3
+  const ROLE_MARKUP = {
+    0: 0.5, // guest
+    1: 0.2, // staff
+    2: 0.1, // influencer
+    3: 0.1, // corporate
+    4: 0.05, // agency
+    100: 0, // admin
   }
-  if (r === 2) return 0.2
-  if (r === 3) return 0.1
-  if (r === 4) return 0.1
-  if (r === 5) return 0.05
-  return 0
+  return ROLE_MARKUP[r] ?? 0
 }


### PR DESCRIPTION
## Summary
- align markup util with fixed percentages for each user role
- update tests to cover new role-based markup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae6eceab34832994182e4a8aa375df