### PR TITLE
Unify TGX booking data with standard fields

### DIFF
--- a/Insiderback-backup260825/src/controllers/booking.controller.js
+++ b/Insiderback-backup260825/src/controllers/booking.controller.js
@@ -13,7 +13,17 @@ const diffDays = (from, to) =>
    Recibe una fila de Booking (snake_case en DB) y la
    convierte al formato camelCase que usa el FE.       */
 const mapStay = (row, source) => {
-  const hotel = row.Hotel ?? null
+  let hotel = row.Hotel ?? null
+  let room  = row.Room  ?? null
+
+  if (source === "tgx" && row.tgxMeta) {
+    const tgxHotel = row.tgxMeta?.hotel ?? {}
+    const tgxRoom  = row.tgxMeta?.rooms?.[0] ?? {}
+    const hotelPlain = hotel && typeof hotel.toJSON === "function" ? hotel.toJSON() : hotel
+    const roomPlain  = room  && typeof room.toJSON  === "function" ? room.toJSON()  : room
+    hotel = { ...hotelPlain, ...tgxHotel }
+    room  = { ...roomPlain,  ...tgxRoom  }
+  }
 
   // Aceptar snake_case o camelCase por si viene mezclado
   const checkIn  = row.check_in  ?? row.checkIn  ?? null
@@ -31,7 +41,7 @@ const mapStay = (row, source) => {
     bookingConfirmation : row.bookingConfirmation ?? row.external_ref ?? null,
 
     /* ─────────── hotel ─────────── */
-    hotel_id   : row.hotel_id ?? null,
+    hotel_id   : row.hotel_id ?? hotel?.id ?? null,
     hotel_name : hotel?.name ?? null,
     location   : hotel
       ? `${hotel.city || hotel.location || ""}, ${hotel.country || ""}`.trim().replace(/, $/, "")
@@ -48,8 +58,8 @@ const mapStay = (row, source) => {
     paymentStatus,
 
     /* ─────────── room info ─────────── */
-    room_type   : row.room_type ?? row.Room?.name ?? null,
-    room_number : row.room_number ?? null,
+    room_type   : row.room_type ?? room?.name ?? null,
+    room_number : row.room_number ?? room?.room_number ?? null,
 
     /* ─────────── guests / total ───── */
     guests : (row.adults ?? 0) + (row.children ?? 0),
@@ -162,6 +172,11 @@ export const getBookingsUnified = async (req, res) => {
         {
           model     : models.Room,
           attributes: ["name"]
+        },
+        {
+          model : models.TGXMeta,
+          as    : "tgxMeta",
+          required: false,
         }
       ],
       order : [["check_in","DESC"]],
@@ -170,14 +185,18 @@ export const getBookingsUnified = async (req, res) => {
     })
 
     // 3. Mapear y unificar
-    const merged = rows
-      .map(r => {
-        const obj = r.toJSON()
-        // tipo: 'outside' si viene de OUTSIDE; caso contrario 'insider'
-        const channel = obj.source === "OUTSIDE" ? "outside" : "insider"
-        return mapStay(obj, channel)
-      })
-      .sort((a, b) => new Date(b.checkIn) - new Date(a.checkIn))
+      const merged = rows
+        .map(r => {
+          const obj = r.toJSON()
+          const channel =
+            obj.source === "TGX"
+              ? "tgx"
+              : obj.source === "OUTSIDE"
+              ? "outside"
+              : "insider"
+          return mapStay(obj, channel)
+        })
+        .sort((a, b) => new Date(b.checkIn) - new Date(a.checkIn))
 
     // 4. Devolver
     return res.json(latest ? merged[0] ?? null : merged)
@@ -342,12 +361,20 @@ export const getBookingById = async (req, res) => {
         ? booking.tgxMeta
         : null
 
+    let hotel = booking.Hotel ? booking.Hotel.get ? booking.Hotel.get({ plain: true }) : booking.Hotel : null
+    let room  = booking.Room  ? booking.Room.get  ? booking.Room.get({ plain: true })  : booking.Room  : null
+
+    if (booking.source === "TGX" && booking.tgxMeta) {
+      hotel = { ...hotel, ...(booking.tgxMeta?.hotel ?? {}) }
+      room  = { ...room,  ...(booking.tgxMeta?.rooms?.[0] ?? {}) }
+    }
+
     return res.json({
       id               : booking.id,
       externalRef      : booking.external_ref,
       user             : booking.User ?? null,
-      hotel            : booking.Hotel,
-      room             : booking.Room,
+      hotel,
+      room,
       checkIn          : booking.check_in,
       checkOut         : booking.check_out,
       nights           : diffDays(booking.check_in, booking.check_out),


### PR DESCRIPTION
## Summary
- Merge TGX hotel and room metadata into booking responses
- Load TGX metadata in unified booking fetch and map TGX source
- Expand stay mapping to use TGX meta for hotel and room info

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae80f9b3188329aed179419c2a338f