### PR TITLE
feat: store and use TGX access code

### DIFF
--- a/Insiderback-backup260825/src/controllers/travelgate-payment.controller.js
+++ b/Insiderback-backup260825/src/controllers/travelgate-payment.controller.js
@@ -332,6 +332,7 @@ export const createTravelgatePaymentIntent = async (req, res) => {
         booking_id: booking.id,
         option_id: String(quoteOptionRefId),
         access: bookingData.access ? String(bookingData.access) : null,
+        access_code: bookingData.access || null,
         room_code: bookingData.roomCode ? String(bookingData.roomCode) : null,
         board_code: bookingData.boardCode ? String(bookingData.boardCode) : null,
         cancellation_policy: bookingData.cancellationPolicy || null,
@@ -557,6 +558,7 @@ export const confirmPaymentAndBook = async (req, res) => {
       price_net:            price?.net ?? null,
       price_gross:          price?.gross ?? null,
       cancellation_policy:  cancelPolicy || null,
+      access_code:          bookingData.access || booking.tgxMeta.access_code || null,
       hotel: tgxBooking?.hotel ? {
         hotelCode:   tgxBooking.hotel.hotelCode,
         hotelName:   tgxBooking.hotel.hotelName,
@@ -917,6 +919,7 @@ export const bookWithCard = async (req, res) => {
         booking_id: booking.id,
         option_id: String(optionRefId),
         access: bookingData.access ? String(bookingData.access) : null,
+        access_code: bookingData.access || null,
         room_code: bookingData.roomCode ? String(bookingData.roomCode) : null,
         board_code: bookingData.boardCode ? String(bookingData.boardCode) : null,
         cancellation_policy: bookingData.cancellationPolicy || null,
@@ -1014,6 +1017,7 @@ export const bookWithCard = async (req, res) => {
       price_net:          price?.net ?? null,
       price_gross:        price?.gross ?? null,
       cancellation_policy: cancelPolicy || null,
+      access_code:        bookingData.access || booking.tgxMeta.access_code || null,
       hotel: tgxBooking?.hotel ? {
         hotelCode: tgxBooking.hotel.hotelCode,
         hotelName: tgxBooking.hotel.hotelName,

--- a/Insiderback-backup260825/src/controllers/travelgate.controller.js
+++ b/Insiderback-backup260825/src/controllers/travelgate.controller.js
@@ -640,7 +640,10 @@ export const cancel = async (req, res, next) => {
     }
 
     // 2) Construir input FORMATO 2 para TGX
-    const accessCode = bk.tgxMeta?.access_code || "2";
+    const accessCode = bk.tgxMeta?.access_code || bk.tgxMeta?.access || null;
+    if (!accessCode) {
+      return res.status(400).json({ error: "Missing access code for cancellation" });
+    }
     const hotelCode = bk.tgxMeta?.hotel_code || "1";
     const refSupplier = bk.tgxMeta?.reference_supplier;
     const refClient = bk.tgxMeta?.reference_client;


### PR DESCRIPTION
## Summary
- store `access_code` when creating TGXMeta records
- keep `access_code` on TGXMeta updates
- require `access_code` for Travelgate cancellation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae8e438c30832987d159f6964272bc