### PR TITLE
feat: add booking read service and endpoint

### DIFF
--- a/Insiderback-backup260825/src/routes/travelgate.routes.js
+++ b/Insiderback-backup260825/src/routes/travelgate.routes.js
@@ -1,11 +1,12 @@
 import { Router } from 'express'
-import { 
-  book, 
-  cancel, 
-  getCategories, 
-  getDestinations, 
-  listHotels, 
-  quote, 
+import {
+  book,
+  readBooking,
+  cancel,
+  getCategories,
+  getDestinations,
+  listHotels,
+  quote,
   search,
   getRooms,
   getBoards,
@@ -26,6 +27,7 @@ router.get("/metadata", getMetadata)         // metadatos del proveedor
 /* ── Booking flow ──────────────────────────────── */
 router.post("/quote", quote)                 // verifica precio
 router.post("/book", book)                   // confirma reserva
+router.post("/booking-read", readBooking)    // lee reserva
 router.post("/cancel", cancel)               // anula reserva
 
 export default router

--- a/Insiderback-backup260825/src/services/tgx.booking.service.js
+++ b/Insiderback-backup260825/src/services/tgx.booking.service.js
@@ -12,7 +12,7 @@ import { requestWithCapture } from "./tgx.capture.js"
 
 /* ---------- helper: client singleton ---------- */
 let _client
-function tgxClient() {
+export function tgxClient() {
   if (_client) return _client
   const endpoint = process.env.TGX_ENDPOINT || "https://api.travelgate.com"
   _client = new GraphQLClient(endpoint, {
@@ -29,7 +29,7 @@ function tgxClient() {
 }
 
 /* ---------- retry helper (backoff exponencial para errores de red) ---------- */
-async function requestWithRetry(doc, variables, { attempts = 3, baseDelayMs = 700 } = {}) {
+export async function requestWithRetry(doc, variables, { attempts = 3, baseDelayMs = 700 } = {}) {
   let lastErr
   for (let i = 0; i < attempts; i++) {
     try {

--- a/Insiderback-backup260825/src/services/tgx.bookingRead.service.js
+++ b/Insiderback-backup260825/src/services/tgx.bookingRead.service.js
@@ -1,0 +1,56 @@
+/*********************************************************************************************
+ * src/services/tgx.bookingRead.service.js
+ * TravelgateX — Booking read service
+ * Reuses client and retry/capture logic from tgx.booking.service.js
+ *********************************************************************************************/
+
+import { gql } from "graphql-request"
+import { requestWithCapture } from "./tgx.capture.js"
+import { requestWithRetry } from "./tgx.booking.service.js"
+
+const BOOKING_READ_Q = gql`
+  query ($criteria: HotelBookingCriteriaInput!, $settings: HotelSettingsInput!) {
+    hotelX {
+      booking(criteria: $criteria, settings: $settings) {
+        bookings {
+          status
+          reference { bookingID client supplier hotel }
+          price { currency net gross binding }
+          holder { name surname }
+          hotel {
+            hotelCode
+            hotelName
+            bookingDate
+            start
+            end
+            boardCode
+            rooms {
+              code
+              description
+              occupancyRefId
+            }
+          }
+          remarks
+        }
+        errors   { code type description }
+        warnings { code type description }
+      }
+    }
+  }
+`
+
+export async function readBookingTGX(criteria, settings) {
+  const parsedCriteria =
+    typeof criteria === "string" ? { bookingID: criteria.trim() } : criteria
+
+  const vars = { criteria: parsedCriteria, settings }
+  const exec = () => requestWithRetry(BOOKING_READ_Q, vars, { attempts: 2 })
+  const data = await requestWithCapture("bookingRead", vars, exec, { doc: BOOKING_READ_Q })
+  const payload = data?.hotelX?.booking || {}
+  return {
+    errors: payload.errors || [],
+    warnings: payload.warnings || [],
+    bookings: payload.bookings || [],
+  }
+}
+


### PR DESCRIPTION
## Summary
- expose tgx client and retry helper for reuse
- add TGX booking read service returning bookings, errors and warnings
- add controller and route for booking read

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af31b931e88329a3b9250f3f2f2293