### PR TITLE
Implement tiered guest markup based on price

### DIFF
--- a/Insiderback-backup260825/src/controllers/travelgate.controller.test.js
+++ b/Insiderback-backup260825/src/controllers/travelgate.controller.test.js
@@ -3,7 +3,13 @@ import assert from 'node:assert'
 import { getMarkup } from '../utils/markup.js'
 
 test('getMarkup returns expected markup for roles', () => {
-  assert.strictEqual(getMarkup(0, 100), 0.5)
+  // guest tiers
+  assert.strictEqual(getMarkup(0, 80), 0.5)
+  assert.strictEqual(getMarkup(0, 100), 0.4)
+  assert.strictEqual(getMarkup(0, 250), 0.4)
+  assert.strictEqual(getMarkup(0, 301), 0.3)
+
+  // other roles
   assert.strictEqual(getMarkup(1, 100), 0.2)
   assert.strictEqual(getMarkup(2, 100), 0.1)
   assert.strictEqual(getMarkup(3, 100), 0.1)

--- a/Insiderback-backup260825/src/utils/markup.js
+++ b/Insiderback-backup260825/src/utils/markup.js
@@ -1,7 +1,15 @@
 export function getMarkup(role, _price) {
   const r = Number(role)
+
+  if (r === 0) {
+    const p = Number(_price)
+    if (!Number.isFinite(p)) return 0.5
+    if (p < 100) return 0.5
+    if (p <= 300) return 0.4
+    return 0.3
+  }
+
   const ROLE_MARKUP = {
-    0: 0.5, // guest
     1: 0.2, // staff
     2: 0.1, // influencer
     3: 0.1, // corporate


### PR DESCRIPTION
## Summary
- apply 50/40/30% markup tiers for guest role depending on nightly price
- reuse markup logic during payment processing
- add tests for tiered guest markup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af873cb1a88329b40176fb695e9a1c