### PR TITLE
Prefill checkout guest info from logged-in user

### DIFF
--- a/insiderweb-backup260825/src/pages/Checkout/Checkout.jsx
+++ b/insiderweb-backup260825/src/pages/Checkout/Checkout.jsx
@@ -457,6 +457,8 @@ const Checkout = () => {
     currency,
   } = useSelector((s) => s.booking)
 
+  const { user, isLoggedIn } = useSelector((s) => s.auth)
+
   // ⬇️ Discount from global state
   const discount = useSelector((s) => s.discount) // { active, percentage, specialDiscountPrice, code, validatedBy? }
 
@@ -505,6 +507,21 @@ const Checkout = () => {
     quoteRateKey,
     discount,
   ])
+
+  useEffect(() => {
+    if (isLoggedIn && user && !guestForm.fullName && !guestForm.email) {
+      const { name, email, phone } = user
+      setGuestForm((prev) => ({
+        ...prev,
+        fullName: name || "",
+        email: email || "",
+        phone: phone || prev.phone,
+      }))
+      dispatch(
+        setGuestInfo({ fullName: name || "", email: email || "", phone: phone || "" })
+      )
+    }
+  }, [isLoggedIn, user])
 
   // Redirect if no selection
   useEffect(() => {


### PR DESCRIPTION
## Summary
- pull `user` and `isLoggedIn` from auth slice on Checkout page
- prefill guest form and booking slice with logged-in user's info

## Testing
- `npm run lint` *(fails: 77 problems, 66 errors, 11 warnings)*
- `npx eslint src/pages/Checkout/Checkout.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68af8744a45c8329a40830a18559ceca